### PR TITLE
Enable install/reinstall of climate buildings

### DIFF
--- a/Defs/ThingCategoryDefs/ThingCategories.xml
+++ b/Defs/ThingCategoryDefs/ThingCategories.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+    <ThingCategoryDef>
+      <defName>BuildingsClimate</defName>
+      <label>climate</label>
+      <parent>Buildings</parent>
+    </ThingCategoryDef>
+</Defs>

--- a/Defs/ThingDefs_Buildings/Buildings_Temperature.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Temperature.xml
@@ -4,12 +4,16 @@
   <ThingDef Abstract="True" Name="CentralizedClimateControlBuilding" ParentName="BuildingBase">
     <category>Building</category>
     <thingClass>Building</thingClass>
+	<minifiedDef>MinifiedThing</minifiedDef>
     <soundImpactDefault>BulletImpact_Metal</soundImpactDefault>
     <selectable>true</selectable>
     <drawerType>MapMeshAndRealTime</drawerType>
     <terrainAffordanceNeeded>Light</terrainAffordanceNeeded>
     <repairEffect>Repair</repairEffect>
     <leaveResourcesWhenKilled>true</leaveResourcesWhenKilled>
+	<thingCategories>
+      <li>BuildingsClimate</li>
+    </thingCategories>
     <statBases>
       <Beauty>-10</Beauty>
     </statBases>
@@ -42,6 +46,7 @@
     <statBases>
       <WorkToBuild>1600</WorkToBuild>
       <MaxHitPoints>100</MaxHitPoints>
+	  <Mass>20</Mass>
       <Flammability>1.0</Flammability>
     </statBases>
     <tickerType>Rare</tickerType>
@@ -244,6 +249,7 @@
     <statBases>
       <WorkToBuild>1600</WorkToBuild>
       <MaxHitPoints>100</MaxHitPoints>
+	  <Mass>20</Mass>
       <Flammability>1.0</Flammability>
     </statBases>
     <tickerType>Rare</tickerType>
@@ -310,6 +316,7 @@
     <statBases>
       <WorkToBuild>4800</WorkToBuild>
       <MaxHitPoints>300</MaxHitPoints>
+	  <Mass>100</Mass>
       <Flammability>1.0</Flammability>
     </statBases>
     <tickerType>Rare</tickerType>
@@ -375,6 +382,7 @@
     <statBases>
       <WorkToBuild>4800</WorkToBuild>
       <MaxHitPoints>300</MaxHitPoints>
+	  <Mass>80</Mass>
       <Flammability>1.0</Flammability>
     </statBases>
     <tickerType>Rare</tickerType>

--- a/Defs/ThingDefs_Buildings/Buildings_Vents.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Vents.xml
@@ -5,11 +5,15 @@
 	<ThingDef Abstract="True" Name="CentralizedClimateControl_BaseVent" ParentName="BuildingBase">
 		<category>Building</category>
 		<thingClass>Building</thingClass>
+		<minifiedDef>MinifiedThing</minifiedDef>
 		<soundImpactDefault>BulletImpact_Metal</soundImpactDefault>
 		<selectable>true</selectable>
 		<drawerType>MapMeshAndRealTime</drawerType>
 		<repairEffect>Repair</repairEffect>
 		<leaveResourcesWhenKilled>true</leaveResourcesWhenKilled>
+		<thingCategories>
+			<li>BuildingsClimate</li>
+		</thingCategories>
 		<statBases>
 			<Beauty>-10</Beauty>
 		</statBases>
@@ -75,6 +79,7 @@
 		<statBases>
 			<WorkToBuild>350</WorkToBuild>
 			<MaxHitPoints>75</MaxHitPoints>
+			<Mass>2</Mass>
 			<Flammability>1.0</Flammability>
 		</statBases>
 		<description>A Wall Mounted Air Vent.</description>
@@ -113,6 +118,7 @@
 		<statBases>
 			<WorkToBuild>175</WorkToBuild>
 			<MaxHitPoints>75</MaxHitPoints>
+			<Mass>1</Mass>
 			<Flammability>1.0</Flammability>
 		</statBases>
 		<description>A Wall Mounted Air Vent.</description>
@@ -151,6 +157,7 @@
 		<statBases>
 			<WorkToBuild>1050</WorkToBuild>
 			<MaxHitPoints>100</MaxHitPoints>
+			<Mass>50</Mass>
 			<Flammability>1.0</Flammability>
 		</statBases>
 		<description>A Surround Exhaust.</description>
@@ -191,6 +198,7 @@
 		<statBases>
 			<WorkToBuild>2100</WorkToBuild>
 			<MaxHitPoints>200</MaxHitPoints>
+			<Mass>100</Mass>
 			<Flammability>1.0</Flammability>
 		</statBases>
 		<description>A Surround Exhaust.</description>
@@ -229,6 +237,7 @@
 		<statBases>
 			<WorkToBuild>1600</WorkToBuild>
 			<MaxHitPoints>100</MaxHitPoints>
+			<Mass>50</Mass>
 			<Flammability>1.0</Flammability>
 		</statBases>
 		<description>An Air Vent.</description>


### PR DESCRIPTION
#11 

I have added a climate building category for storage zones, all the climate buildings will be under it. Buildings have been given a mass value reflecting some vanilla values, which are quite arbitrary anyway. Most importantly, these changes allow you to uninstall buildings instead of unnecessarily deconstructing.