### PR TITLE
Add localization for Wide Surround Air Vent

### DIFF
--- a/Languages/English/DefInjected/ThingDef/Buildings_Temperature.xml
+++ b/Languages/English/DefInjected/ThingDef/Buildings_Temperature.xml
@@ -47,4 +47,10 @@
   <SurroundAirVent_Blueprint.label>Surround Air Vent (Blueprint)</SurroundAirVent_Blueprint.label>
   <SurroundAirVent_Frame.label>Surround Air Vent (Building)</SurroundAirVent_Frame.label>
   <SurroundAirVent_Frame.description>Exhausts the air in all directions in a room from a Pipe Network.</SurroundAirVent_Frame.description>
+
+  <SurroundAirVentWide.label>Wide Surround Air Vent</SurroundAirVentWide.label>
+  <SurroundAirVentWide.description>This device takes air from a Pipe Network and dumps it in the connected room or outside environment.</SurroundAirVentWide.description>
+  <SurroundAirVentWide_Blueprint.label>Wide Surround Air Vent (Blueprint)</SurroundAirVentWide_Blueprint.label>
+  <SurroundAirVentWide_Frame.label>Wide Surround Air Vent (Building)</SurroundAirVentWide_Frame.label>
+  <SurroundAirVentWide_Frame.description>Exhausts the air in all directions in a room from a Pipe Network.</SurroundAirVentWide_Frame.description>
 </LanguageData>


### PR DESCRIPTION
Resolves #13 by basically duplicating the descriptions present for the original 1x1 surround vent but adding the word "wide".