### PR TITLE
Move Air Conditioning prerequisite from buildings to research project

### DIFF
--- a/Defs/ResearchProjectDefs/ResearchProjects.xml
+++ b/Defs/ResearchProjectDefs/ResearchProjects.xml
@@ -8,6 +8,7 @@
     <techLevel>Industrial</techLevel>
     <prerequisites>
       <li>Electricity</li>
+      <li>AirConditioning</li>
     </prerequisites>
     <researchViewX>2</researchViewX>
     <researchViewY>5</researchViewY>
@@ -22,6 +23,7 @@
     <prerequisites>
       <li>BasicClimateControl</li>
       <li>Electricity</li>
+      <li>AirConditioning</li>
     </prerequisites>
     <researchViewX>3</researchViewX>
     <researchViewY>5</researchViewY>

--- a/Defs/ThingDefs_Buildings/Buildings_Temperature.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Temperature.xml
@@ -71,7 +71,6 @@
     <designationCategory>CentralClimateControl</designationCategory>
     <designationHotKey>Misc4</designationHotKey>
     <researchPrerequisites>
-      <li>AirConditioning</li>
       <li>BasicClimateControl</li>
     </researchPrerequisites>
     <placeWorkers>
@@ -106,7 +105,6 @@
     <terrainAffordanceNeeded>Light</terrainAffordanceNeeded>
     <designationHotKey>Misc1</designationHotKey>
     <researchPrerequisites>
-      <li>AirConditioning</li>
       <li>BasicClimateControl</li>
     </researchPrerequisites>
     <placeWorkers>
@@ -274,7 +272,6 @@
     <designationCategory>CentralClimateControl</designationCategory>
     <designationHotKey>Misc4</designationHotKey>
     <researchPrerequisites>
-      <li>AirConditioning</li>
       <li>BasicClimateControl</li>
     </researchPrerequisites>
     <placeWorkers>
@@ -339,7 +336,6 @@
     <designationCategory>CentralClimateControl</designationCategory>
     <designationHotKey>Misc4</designationHotKey>
     <researchPrerequisites>
-      <li>AirConditioning</li>
       <li>IndustrialClimateControl</li>
     </researchPrerequisites>
     <placeWorkers>
@@ -405,7 +401,6 @@
     <designationCategory>CentralClimateControl</designationCategory>
     <designationHotKey>Misc4</designationHotKey>
     <researchPrerequisites>
-      <li>AirConditioning</li>
       <li>IndustrialClimateControl</li>
     </researchPrerequisites>
     <placeWorkers>

--- a/Defs/ThingDefs_Buildings/Buildings_Vents.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Vents.xml
@@ -15,7 +15,6 @@
 		</statBases>
 		<clearBuildingArea>false</clearBuildingArea>
 		<researchPrerequisites>
-			<li>AirConditioning</li>
 			<li>BasicClimateControl</li>
 		</researchPrerequisites>
 		<designationCategory>CentralClimateControl</designationCategory>


### PR DESCRIPTION
Because buildings depended on multiple things, some mods get a bit confused and display confusing information to end-users, leading them to believe that either research project was all that was needed. Even in the base game, this was somewhat present since the research tree did not make it clear that Air Conditioning is a prerequisite.
This change moves the dependency upon the Air Conditioning research project from the buildings to the Basic Climate Control research project. This both fixes the research tree to explicitly require/show the dependency and prevents mods from being confused about which project is actually needed.
Resolves #14